### PR TITLE
Update 'getting' page for fedora

### DIFF
--- a/source/getting.html.haml.markdown
+++ b/source/getting.html.haml.markdown
@@ -6,7 +6,7 @@
 
   ### Fedora
 
-  A `flatpak` package is available for Fedora from version 22.
+  A `flatpak` package will be available shortly for Fedora from version 22.
 
   ### Ubuntu
 


### PR DESCRIPTION
Reflect the fact that the renamed package is not available yet.
